### PR TITLE
Decide owner based on shed file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,11 @@ jobs:
         - set -e
         - |
           if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-              # while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_key "$TEST_SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
-              while read -r DIR; do planemo shed_update --shed_target toolshed --owner immport-devteam --shed_key "$SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+              while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_key "$TEST_SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+              while read -r DIR; do
+                owner=$(grep owner: "$DIR"/.shed.yml | awk '{ print $2 }')
+                planemo shed_update --shed_target toolshed --owner $owner --shed_key "$SHED_KEY" --force_repository_creation "$DIR" || exit 1;
+              done < changed_repositories.list
           fi
 
 before_script:
@@ -40,4 +43,3 @@ script:
 
 notifications:
   email: false
-

--- a/flowtools/cs_overview/.shed.yml
+++ b/flowtools/cs_overview/.shed.yml
@@ -1,6 +1,6 @@
 owner: immport-devteam
 name: cs_overview
-description: generates an overview of the flow analysis results
+description: generates an overview of the flow analysis results.
 long_description: |
     **Input**
     Input files are tab-separated files containing counts of events in each population for each file compared to reference population patterns, MFI for each marker in each population for each file, and individual files used in the comparison. The output from a Cross Sample analysis as well as from mapping individual files to a FlowSOM reference tree are suitable files.


### PR DESCRIPTION
This make the CI choose the owner to use based on the .shed file in the directory, to accomodate for the cases where we need to have azomics or immport-dev-team.