### PR TITLE
Check fcs headers: fixes .shed for deployment

### DIFF
--- a/flowtools/check_fcs_headers/.shed.yml
+++ b/flowtools/check_fcs_headers/.shed.yml
@@ -1,5 +1,5 @@
 owner: immport-devteam
-name: check_fcs_header
+name: check_fcs_headers
 description: returns a table of the headers of a set of FCS files
 long_description: |
     **Input**


### PR DESCRIPTION
Last deployment to the toolshed failed due to an incorrect shed name for the repo.