### PR TITLE
[WIP] FCSgatetrans tool - Detect alternative spill over matrix name

### DIFF
--- a/flowtools/fcs_gate_trans/FCSGateTrans.R
+++ b/flowtools/fcs_gate_trans/FCSGateTrans.R
@@ -300,6 +300,10 @@ processFCSFile <- function(input_file, output_file="", compensate=FALSE,
   # Compensate
   #
   spill <- keywords$SPILL
+  
+  if(is.null(spill)){ 
+      spill <- keywords[["$SPILLOVER"]]
+  }
 
   if (is.null(spill) == FALSE && compensate == TRUE) {
     if (debug) {


### PR DESCRIPTION
This commit should detect an alternative name for the spillover matrix stored in the keywords. There has been one set of FCS files I found externally where the spillover matrix was labelled as such. I thought it would be useful to have this PR for in the future, if you come across this issue again. Alternative ways of labelling the spillover matrix could easily be added here as well.