### PR TITLE
Produce log with stderr and stdout for flow_compensate

### DIFF
--- a/flowtools/flow_compensate/flow-compensate.xml
+++ b/flowtools/flow_compensate/flow-compensate.xml
@@ -1,4 +1,4 @@
-<tool id="flow-compensate" name="Flow compensate" version="0.1.0+galaxy1" profile="19.01" python_template_version="3.5">
+<tool id="flow-compensate" name="Flow compensate" version="0.1.0+galaxy0" profile="19.01" python_template_version="3.5">
     <description>
         compensates a set of FCS objects through a compensation matrix
     </description>

--- a/flowtools/flow_compensate/flow-compensate.xml
+++ b/flowtools/flow_compensate/flow-compensate.xml
@@ -1,4 +1,4 @@
-<tool id="flow-compensate" name="Flow compensate" version="0.1.0+galaxy0" profile="19.01" python_template_version="3.5">
+<tool id="flow-compensate" name="Flow compensate" version="0.1.0+galaxy1" profile="19.01" python_template_version="3.5">
     <description>
         compensates a set of FCS objects through a compensation matrix
     </description>
@@ -11,7 +11,7 @@
           ln -s '$fcs' input_dir/'$fcs.element_identifier';
         #end for 
         mkdir -p output_dir;
-        Rscript '$compensate_script' '$compensation_matrix' input_dir output_dir
+        Rscript '$compensate_script' '$compensation_matrix' input_dir output_dir &> '$log_file'
       ]]></command>
     <configfiles>
       <configfile name="compensate_script"><![CDATA[
@@ -47,6 +47,7 @@ write.flowSet(samp, outdir=args[[ 3 ]])
       <collection name="compensated_fcs" format="fcs" label="${tool.name} compensated FCS files on ${on_string}" type="list">
         <discover_datasets pattern="__designation_and_ext__" directory="output_dir" visible="true" />
       </collection>
+      <data name="log_file" format="txt" label="Log for compensation by ${tool.name} on ${on_string}"/> 
     </outputs>
     <help><![CDATA[
         TODO: Fill in help.


### PR DESCRIPTION
Flow compensate only produces lists of results, as such if it fails there is no visible error. This enables a log file to be captured.